### PR TITLE
fix: JWT secret caching issue causing authentication failures

### DIFF
--- a/server/controllers/AuthController.js
+++ b/server/controllers/AuthController.js
@@ -5,7 +5,11 @@ import DatabaseService from '../services/DatabaseService.js';
 class AuthController {
   constructor() {
     this.databaseService = new DatabaseService();
-    this.jwtSecret = process.env.JWT_SECRET || 'your-secret-key';
+    // Don't cache JWT_SECRET - read it fresh each time
+  }
+
+  getJwtSecret() {
+    return process.env.JWT_SECRET || 'your-secret-key';
   }
 
   async login(req, res) {
@@ -46,7 +50,7 @@ class AuthController {
           username: user.email, 
           role: 'admin' 
         },
-        this.jwtSecret,
+        this.getJwtSecret(),
         { expiresIn: '24h' }
       );
 
@@ -106,7 +110,7 @@ class AuthController {
           username: user.username, 
           role: user.role 
         },
-        this.jwtSecret,
+        this.getJwtSecret(),
         { expiresIn: '24h' }
       );
 


### PR DESCRIPTION
- Remove JWT_SECRET caching in AuthController constructor
- Add getJwtSecret() method to read JWT_SECRET fresh each time
- Fixes issue where login succeeds but subsequent API calls fail with 'Invalid token'
- Ensures consistent JWT secret usage between token generation and verification